### PR TITLE
[NFC] Use llvm::StringSwitch maybe?

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -17,22 +17,22 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: install clang-format
-        run: sudo apt install -y clang-format
       - name: Comparing PR against target branch
         env:
           PR_NUMBER: ${{ github.event.number }}
           GH_TOKEN: ${{ github.token }}
         run: |
-            echo Comparing $GITHUB_BASE_REF vs HEAD
-            git diff -U0 --no-color origin/$GITHUB_BASE_REF..HEAD | clang-format-diff -p1 | tee format.diff
-            if [ -s "format.diff" ]
+            echo Comparing $PR_NUMBER vs target branch
+            git fetch origin refs/pull/$PR_NUMBER/head:pull/$PR_NUMBER
+            git checkout pull/$PR_NUMBER
+            git diff -U0 --no-color $GITHUB_REF..pull/$PR_NUMBER | clang-format-diff-15 -p1 | tee format.diff
+            if [ -s format.diff ]
             then
               echo PR contains clang-format violations. First 50 lines of the diff: >> message.txt
-              echo ``` >> message.txt
+              echo \`\`\`diff >> message.txt
               cat format.diff | head -n 50 >> message.txt
-              echo ``` >> message.txt
-              echo See [action log]\(https://github.com/microsoft/DirectXShaderCompiler/actions/runs/$GITHUB_RUN_ID/job/$GITHUB_JOB\) for the full diff.  >> message.txt
+              echo \`\`\` >> message.txt
+              echo See [action log]\(https://github.com/microsoft/DirectXShaderCompiler/actions/runs/$GITHUB_RUN_ID/) for the full diff.  >> message.txt
               gh pr comment $PR_NUMBER --body-file message.txt
               exit 1
             fi

--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -32,7 +32,7 @@ jobs:
               echo \`\`\`diff >> message.txt
               cat format.diff | head -n 50 >> message.txt
               echo \`\`\` >> message.txt
-              echo See [action log]\(https://github.com/microsoft/DirectXShaderCompiler/actions/runs/$GITHUB_RUN_ID/) for the full diff.  >> message.txt
+              echo See [action log]\(https://github.com/microsoft/DirectXShaderCompiler/actions/runs/$GITHUB_RUN_ID/\) for the full diff.  >> message.txt
               gh pr comment $PR_NUMBER --body-file message.txt
               exit 1
             fi

--- a/lib/Support/assert.cpp
+++ b/lib/Support/assert.cpp
@@ -25,7 +25,8 @@ void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
 
 #include <assert.h>
 
-void llvm_assert(const char *message, const char *, unsigned) {
+void llvm_assert(const char *message, const char *, unsigned,
+                 const char *_Function) {
   assert(false && message);
 }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12054,74 +12054,26 @@ SpirvConstant *SpirvEmitter::tryToEvaluateAsConst(const Expr *expr) {
   return nullptr;
 }
 
-hlsl::ShaderModel::Kind SpirvEmitter::getShaderModelKind(StringRef stageName) {
-  hlsl::ShaderModel::Kind smk;
-  switch (stageName[0]) {
-  case 'c':
-    switch (stageName[1]) {
-    case 'o':
-      smk = hlsl::ShaderModel::Kind::Compute;
-      break;
-    case 'l':
-      smk = hlsl::ShaderModel::Kind::ClosestHit;
-      break;
-    case 'a':
-      smk = hlsl::ShaderModel::Kind::Callable;
-      break;
-    default:
-      smk = hlsl::ShaderModel::Kind::Invalid;
-      break;
-    }
-    break;
-  case 'v':
-    smk = hlsl::ShaderModel::Kind::Vertex;
-    break;
-  case 'h':
-    smk = hlsl::ShaderModel::Kind::Hull;
-    break;
-  case 'd':
-    smk = hlsl::ShaderModel::Kind::Domain;
-    break;
-  case 'g':
-    smk = hlsl::ShaderModel::Kind::Geometry;
-    break;
-  case 'p':
-    smk = hlsl::ShaderModel::Kind::Pixel;
-    break;
-  case 'r':
-    smk = hlsl::ShaderModel::Kind::RayGeneration;
-    break;
-  case 'i':
-    smk = hlsl::ShaderModel::Kind::Intersection;
-    break;
-  case 'a':
-    switch (stageName[1]) {
-    case 'm':
-      smk = hlsl::ShaderModel::Kind::Amplification;
-      break;
-    case 'n':
-      smk = hlsl::ShaderModel::Kind::AnyHit;
-      break;
-    }
-    break;
-  case 'm':
-    switch (stageName[1]) {
-    case 'e':
-      smk = hlsl::ShaderModel::Kind::Mesh;
-      break;
-    case 'i':
-      smk = hlsl::ShaderModel::Kind::Miss;
-      break;
-    }
-    break;
-  default:
-    smk = hlsl::ShaderModel::Kind::Invalid;
-    break;
-  }
-  if (smk == hlsl::ShaderModel::Kind::Invalid) {
-    llvm_unreachable("unknown stage name");
-  }
-  return smk;
+hlsl::ShaderModel::Kind SpirvEmitter::getShaderModelKind(StringRef stageName)
+{
+  hlsl::ShaderModel::Kind SMK = llvm::StringSwitch<hlsl::ShaderModel::Kind>(stageName)
+      .Case("pixel", hlsl::ShaderModel::Kind::Pixel)
+      .Case("vertex", hlsl::ShaderModel::Kind::Vertex)
+      .Case("geometry", hlsl::ShaderModel::Kind::Geometry)
+      .Case("hull", hlsl::ShaderModel::Kind::Hull)
+      .Case("domain", hlsl::ShaderModel::Kind::Domain)
+      .Case("compute", hlsl::ShaderModel::Kind::Compute)
+      .Case("raygeneration", hlsl::ShaderModel::Kind::RayGeneration)
+      .Case("intersection", hlsl::ShaderModel::Kind::Intersection)
+      .Case("anyhit", hlsl::ShaderModel::Kind::AnyHit)
+      .Case("closesthit", hlsl::ShaderModel::Kind::ClosestHit)
+      .Case("miss", hlsl::ShaderModel::Kind::Miss)
+      .Case("callable", hlsl::ShaderModel::Kind::Callable)
+      .Case("mesh", hlsl::ShaderModel::Kind::Mesh)
+      .Case("amplification", hlsl::ShaderModel::Kind::Amplification)
+      .Default(hlsl::ShaderModel::Kind::Invalid);
+  assert(SMK != hlsl::ShaderModel::Kind::Invalid);
+  return SMK;
 }
 
 spv::ExecutionModel

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12054,24 +12054,24 @@ SpirvConstant *SpirvEmitter::tryToEvaluateAsConst(const Expr *expr) {
   return nullptr;
 }
 
-hlsl::ShaderModel::Kind SpirvEmitter::getShaderModelKind(StringRef stageName)
-{
-  hlsl::ShaderModel::Kind SMK = llvm::StringSwitch<hlsl::ShaderModel::Kind>(stageName)
-      .Case("pixel", hlsl::ShaderModel::Kind::Pixel)
-      .Case("vertex", hlsl::ShaderModel::Kind::Vertex)
-      .Case("geometry", hlsl::ShaderModel::Kind::Geometry)
-      .Case("hull", hlsl::ShaderModel::Kind::Hull)
-      .Case("domain", hlsl::ShaderModel::Kind::Domain)
-      .Case("compute", hlsl::ShaderModel::Kind::Compute)
-      .Case("raygeneration", hlsl::ShaderModel::Kind::RayGeneration)
-      .Case("intersection", hlsl::ShaderModel::Kind::Intersection)
-      .Case("anyhit", hlsl::ShaderModel::Kind::AnyHit)
-      .Case("closesthit", hlsl::ShaderModel::Kind::ClosestHit)
-      .Case("miss", hlsl::ShaderModel::Kind::Miss)
-      .Case("callable", hlsl::ShaderModel::Kind::Callable)
-      .Case("mesh", hlsl::ShaderModel::Kind::Mesh)
-      .Case("amplification", hlsl::ShaderModel::Kind::Amplification)
-      .Default(hlsl::ShaderModel::Kind::Invalid);
+hlsl::ShaderModel::Kind SpirvEmitter::getShaderModelKind(StringRef stageName) {
+  hlsl::ShaderModel::Kind SMK =
+      llvm::StringSwitch<hlsl::ShaderModel::Kind>(stageName)
+          .Case("pixel", hlsl::ShaderModel::Kind::Pixel)
+          .Case("vertex", hlsl::ShaderModel::Kind::Vertex)
+          .Case("geometry", hlsl::ShaderModel::Kind::Geometry)
+          .Case("hull", hlsl::ShaderModel::Kind::Hull)
+          .Case("domain", hlsl::ShaderModel::Kind::Domain)
+          .Case("compute", hlsl::ShaderModel::Kind::Compute)
+          .Case("raygeneration", hlsl::ShaderModel::Kind::RayGeneration)
+          .Case("intersection", hlsl::ShaderModel::Kind::Intersection)
+          .Case("anyhit", hlsl::ShaderModel::Kind::AnyHit)
+          .Case("closesthit", hlsl::ShaderModel::Kind::ClosestHit)
+          .Case("miss", hlsl::ShaderModel::Kind::Miss)
+          .Case("callable", hlsl::ShaderModel::Kind::Callable)
+          .Case("mesh", hlsl::ShaderModel::Kind::Mesh)
+          .Case("amplification", hlsl::ShaderModel::Kind::Amplification)
+          .Default(hlsl::ShaderModel::Kind::Invalid);
   assert(SMK != hlsl::ShaderModel::Kind::Invalid);
   return SMK;
 }

--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -89,7 +89,7 @@ add_lit_testsuite(check-clang "Running the Clang regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   #LIT ${LLVM_LIT}
   PARAMS ${CLANG_TEST_PARAMS}
-    skip_taef_exec=True
+    skip_taef_exec=False
   DEPENDS ${CLANG_TEST_DEPS}
   ARGS ${CLANG_TEST_EXTRA_ARGS}
   )

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -311,6 +311,11 @@ if "%TEST_USE_LIT%"=="1" (
     cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-all
     set RES_CLANG=!ERRORLEVEL!
     set RES_DXILCONV=!RES_CLANG!
+    rem check exec.
+    if defined EXEC_ADAPTER (
+        echo The -adapter parameter is supported only when running just execution tests ^(hcttest.cmd exec^)
+      )
+    set RES_EXEC=!ERRORLEVEL!
   ) else (
     if "%TEST_DXILCONV%"=="1" (
       cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-dxilconv


### PR DESCRIPTION
This replaces a hand-rolled string parser with an
llvm::StringSwitch that matches full strings. This should be more resilient and maintainable.